### PR TITLE
Update deflate.cpp

### DIFF
--- a/src/zopfli/deflate.cpp
+++ b/src/zopfli/deflate.cpp
@@ -789,7 +789,7 @@ static void AddLZ77Block(int btype, int final,
       else{
         //TODO: This may make compression worse due to longer huffman headers.
         outpred = 3;
-        outpred += GetDynamicLengths(litlens, dists, 0, lend, ll_lengths, d_lengths, 1, symbols, 1);
+        outpred += GetDynamicLengths(litlens, dists, 0, lend, ll_lengths, d_lengths, 1, symbols);
         if (replaceCodes - i  < 3){
           outpred += CalculateTreeSize(ll_lengths, d_lengths, hq, &best);
         }


### PR DESCRIPTION
My first pull request ever on here, so apologies in advance if I'm not doing this right. Just corrected what I'm pretty sure was a very simple typo - removing the extra ", 1" on the end there makes the package compile again on all systems, so unless I'm wrong (and I've never programmed in any version of C/C++, so I could be - I'm only troubleshooting the error that gcc led me directly to), I think its inclusion there on the end was likely a mistake. Thanks for all the time you spend updating ECT - it's a fantastic tool, and I make sure to mention it when and wherever I get the chance.