### PR TITLE
correcting case of executable in install

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,4 +39,4 @@ mozjpeg:
 	make
 install: all
 	$(MAKEDIR) $(DESTDIR)$(BINDIR)
-	$(INSTALL) ../ECT $(DESTDIR)$(BINDIR)
+	$(INSTALL) ../ect $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
Really simple change to the install target to reflect the new name of the binary.