### PR TITLE
Add unistd.h to gztools.cpp

### DIFF
--- a/src/gztools.cpp
+++ b/src/gztools.cpp
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <unistd.h>
 
 int ungz(const char * Infile, const char * Outfile){
     gzFile r = gzopen(Infile, "rb");


### PR DESCRIPTION
Fixes compilation error where "unlink()" is not found

This occurs on OSX Sierra using the latest Clang or GCC7