### PR TITLE
Add appendable flags to Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,6 +24,7 @@ bin: deps
 	$(CXX) $(UCXXFLAGS) main.cpp $(OBJECTS) $(CXXSRC) mozjpeg/.libs/libjpeg.a libpng/libpng.a zlib/libz.a -o ../ect $(LDFLAGS)
 clean:
 	rm -f *.o zlib/*.o zlib/*.a libpng/*.o libpng/*.a libpng/pngusr.h libpng/pnglibconf.h
+	make -C mozjpeg clean
 deps: zlib libpng mozjpeg
 zlib:
 	cd zlib/; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,8 +35,8 @@ libpng:
 	make -C libpng/ -f scripts/makefile.linux-opt CC="$(CC)" CFLAGS="$(UCFLAGS) -DPNG_USER_CONFIG -Wno-macro-redefined" libpng.a
 mozjpeg:
 	cd mozjpeg/; \
-	./configure --disable-dependency-tracking --disable-shared --without-turbojpeg --without-java CC="$(CC)" CFLAGS="$(UCFLAGS)"; \
-	make
+	./configure --disable-dependency-tracking --disable-shared --without-turbojpeg --without-java CC="$(CC)" CFLAGS="$(UCFLAGS)" LDFLAGS=""; \
+	make LDFLAGS=""
 install: all
 	$(MAKEDIR) $(DESTDIR)$(BINDIR)
 	$(INSTALL) ../ect $(DESTDIR)$(BINDIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CXX = g++
-CFLAGS = -Ofast -std=gnu11 -fsigned-char
-CXXFLAGS= -pthread -Ofast -std=gnu++11 -fsigned-char
+UCFLAGS = -Ofast -std=gnu11 -fsigned-char $(CFLAGS)
+UCXXFLAGS = -pthread -Ofast -std=gnu++11 -fsigned-char $(CXXFLAGS)
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 INSTALL ?= install
@@ -19,22 +19,22 @@ leanify/zip.cpp leanify/leanify.cpp
 all: deps bin
 
 bin: deps
-	$(CC) -c $(CFLAGS) optipng/codec.c optipng/image.c zopfli//util.c zopfli/squeeze.c zopfli/lz77.c \
+	$(CC) -c $(UCFLAGS) optipng/codec.c optipng/image.c zopfli//util.c zopfli/squeeze.c zopfli/lz77.c \
 	zopfli/blocksplitter.c optipng/opngreduc/opngreduc.c LzFind.c miniz/miniz.c
-	$(CXX) $(CXXFLAGS) main.cpp $(OBJECTS) $(CXXSRC) mozjpeg/.libs/libjpeg.a libpng/libpng.a zlib/libz.a -o ../ect
+	$(CXX) $(UCXXFLAGS) main.cpp $(OBJECTS) $(CXXSRC) mozjpeg/.libs/libjpeg.a libpng/libpng.a zlib/libz.a -o ../ect $(LDFLAGS)
 clean:
 	rm -f *.o zlib/*.o zlib/*.a libpng/*.o libpng/*.a libpng/pngusr.h libpng/pnglibconf.h
 deps: zlib libpng mozjpeg
 zlib:
 	cd zlib/; \
-	$(CC) $(CFLAGS) -c adler32.c crc32.c deflate.c inffast.c inflate.c inftrees.c trees.c zutil.c gzlib.c gzread.c; \
+	$(CC) $(UCFLAGS) -c adler32.c crc32.c deflate.c inffast.c inflate.c inftrees.c trees.c zutil.c gzlib.c gzread.c; \
 	ar rcs libz.a adler32.o crc32.o deflate.o inffast.o inflate.o inftrees.o trees.o zutil.o gzlib.o gzread.o
 libpng:
 	cp pngusr.h libpng/pngusr.h
-	make -C libpng/ -f scripts/makefile.linux-opt CC="$(CC)" CFLAGS="$(CFLAGS) -DPNG_USER_CONFIG -Wno-macro-redefined" libpng.a
+	make -C libpng/ -f scripts/makefile.linux-opt CC="$(CC)" CFLAGS="$(UCFLAGS) -DPNG_USER_CONFIG -Wno-macro-redefined" libpng.a
 mozjpeg:
 	cd mozjpeg/; \
-	./configure --disable-dependency-tracking --disable-shared --without-turbojpeg --without-java CC="$(CC)" CFLAGS="$(CFLAGS)"; \
+	./configure --disable-dependency-tracking --disable-shared --without-turbojpeg --without-java CC="$(CC)" CFLAGS="$(UCFLAGS)"; \
 	make
 install: all
 	$(MAKEDIR) $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
Allows user environment CFLAGS/CXXFLAGS to be specified which append to
defaults. Also adds LDFLAGS to the final etc compilation step.

This allows the user to compile and link with Boost easily from the
command line, by using a command like:
`make CXXFLAGS="-DBOOST_SUPPORTED -I/usr/local/opt/boost/include"
LDFLAGS="-L/usr/local/opt/boost/lib -lboost_system -lboost_filesystem"`