### PR TITLE
fix Windows build

### DIFF
--- a/src/gztools.cpp
+++ b/src/gztools.cpp
@@ -12,7 +12,9 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 int ungz(const char * Infile, const char * Outfile){
     gzFile r = gzopen(Infile, "rb");

--- a/src/leanify/leanify.cpp
+++ b/src/leanify/leanify.cpp
@@ -1,6 +1,6 @@
-#include <unistd.h>
 #include <fcntl.h>
 #ifndef _WIN32
+#include <unistd.h>
 #include <sys/mman.h>
 #endif
 

--- a/src/leanify/zip.cpp
+++ b/src/leanify/zip.cpp
@@ -4,14 +4,15 @@
 #include <string>
 #include <vector>
 #include <fcntl.h>
-#include <unistd.h>
 #include <algorithm>
 #ifdef _WIN32
+#define NOMINMAX
 #include <Windows.h>
 #ifdef _MSC_VER
 #include <io.h>
 #endif
 #else
+#include <unistd.h>
 #include <sys/param.h>
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,6 @@
 #include "main.h"
 #include "support.h"
 #include "miniz/miniz.h"
-#include <unistd.h>
 #include <limits.h>
 #include <atomic>
 
@@ -20,6 +19,8 @@
 
 #ifdef _WIN32
 #include <Windows.h>
+#else
+#include <unistd.h>
 #endif
 
 static std::atomic<size_t> processedfiles;

--- a/src/optipng/CMakeLists.txt
+++ b/src/optipng/CMakeLists.txt
@@ -18,7 +18,10 @@ add_library(optipng::optipng ALIAS optipng)
 #make sure that we are using custom zlib and custom libpng options
 set(PNG_BUILD_ZLIB ON CACHE BOOL "use custom zlib within libpng" FORCE)
 set(ZLIB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../zlib/ CACHE FILEPATH "custom zlib directory" FORCE)
-add_compile_options(-Wno-macro-redefined)
+if(MSVC)
+else()
+	add_compile_options(-Wno-macro-redefined)
+endif()
 add_compile_definitions(PNG_USER_CONFIG)
 
 add_subdirectory(../libpng libpng EXCLUDE_FROM_ALL)

--- a/src/optipng/optipng.cpp
+++ b/src/optipng/optipng.cpp
@@ -24,7 +24,9 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "trans.h"
 #include "opngcore.h"

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -8,8 +8,13 @@
 
 #include "support.h"
 #include <sys/stat.h>
+#ifdef _MSC_VER
+#include <io.h>
+#define access _access
+#define W_OK 2
+#endif
 #include <time.h>
-#include <utime.h>
+#include <sys/utime.h>
 #include <stdio.h>
 
 long long filesize (const char * Infile) {

--- a/src/support.h
+++ b/src/support.h
@@ -9,7 +9,9 @@
 #ifndef __Efficient_Compression_Tool__support__
 #define __Efficient_Compression_Tool__support__
 
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <time.h>
 
 // Returns Filesize of Infile

--- a/src/zlib/deflate.c
+++ b/src/zlib/deflate.c
@@ -48,6 +48,11 @@
  */
 
 #include "deflate.h"
+#ifdef _MSC_VER
+#define ALWAYS_INLINE __forceinline
+#else
+#define ALWAYS_INLINE __attribute__((alsways_inline))
+#endif
 
 typedef enum {
     need_more,      /* block not completed, need more input or more output */
@@ -125,7 +130,7 @@ x86_compute_hash(deflate_state *s, const unsigned char *str) {
  *    previous key instead of complete recalculation each time.
  */
 #ifndef UPDATE_HASH
-    __attribute__ ((always_inline)) inline static unsigned
+    ALWAYS_INLINE inline static unsigned
     _update_hash(deflate_state *s, unsigned h, const unsigned char *str)  {
         return (((h << s->hash_shift) ^ *(str)) & (s->hash_mask));
     }
@@ -151,7 +156,7 @@ x86_compute_hash(deflate_state *s, const unsigned char *str) {
     match_head = s->prev[(str) & s->w_mask] = s->head[s->ins_h], \
     s->head[s->ins_h] = (Pos)(str))
 
-__attribute__ ((always_inline)) inline static void
+ALWAYS_INLINE inline static void
 bulk_insert_str(deflate_state *s, Pos startpos, unsigned count) {
     unsigned idx;
     for (idx = 0; idx < count; idx++) {
@@ -1163,7 +1168,7 @@ deflate_state *s;
            */
           {
             int i;
-            typeof(p) q = p - n;
+            Pos *q = p - n;
             for (i = 0; i < n; i++) {
               Pos m = *q;
               Pos t = wsize;
@@ -1182,7 +1187,7 @@ deflate_state *s;
           p = &s->prev[n];
           {
             int i;
-            typeof(p) q = p - n;
+            Pos *q = p - n;
             for (i = 0; i < n; i++) {
               Pos m = *q;
               Pos t = wsize;

--- a/src/zlib/deflate.h
+++ b/src/zlib/deflate.h
@@ -310,7 +310,12 @@ void ZLIB_INTERNAL _tr_stored_block(deflate_state *s, char *buf,
 extern const uint8_t ZLIB_INTERNAL _length_code[];
 extern const uint8_t ZLIB_INTERNAL _dist_code[];
 
+#ifndef _MSC_VER
 #define likely(x)       __builtin_expect((x),1)
 #define unlikely(x)     __builtin_expect((x),0)
+#else
+#define likely(x)      x
+#define unlikely(x)    x
+#endif
 
 #endif /* DEFLATE_H */

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -24,6 +24,10 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+#if _MSC_VER
+#include <malloc.h>
+#define alloca _alloca
+#endif
 
 #include "blocksplitter.h"
 #include "deflate.h"


### PR DESCRIPTION
- MSVC does not support “__builtin_expect()”
- MSVC requires “__forceinline” in place of “__attribute__((always_inline))”
- MSVC does not have a “-Wno-macro-redefined” switch
- MSVC requires “_alloca()” in place of “alloca()”
- MSVC requires “_access()” in place of “access()”; Windows does not provide file access mode macros
- “typeof()” is a GCC extension;
- Windows does not provide <unistd.h>
- “std::max()” conflicts with <Windows.h> macro