### PR TITLE
Fix zopfli, zlib link order

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,8 +133,8 @@ target_link_libraries(ect
 	lodepng::lodepng
 	miniz::miniz
 	optipng::optipng
-	zlib::zlib
 	zopfli::zopfli
+	zlib::zlib
 	jpeg-static)
 
 # mozjpeg generates some header files that we need to be able to include


### PR DESCRIPTION
Commit 520aa9df065ea8289199d282c377f46e28602334 adds references to zlib in zopfli. GNU ld expects libraries containing a function to appear after objects and libraries referencing it. Fixes #96.