### PR TITLE
Fix building for ARM-based macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Ignore built objects and build output
 *.o
 *.a
+build/
+
+# MacOS junk files
 .DS_Store

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,7 +113,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clan
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mpclmul -msse4.2")
   elseif(CPU_TYPE STREQUAL arm64)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a+crc")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a+crcc")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a+crc")
   endif()
 endif()
 

--- a/src/zlib/crc32.c
+++ b/src/zlib/crc32.c
@@ -24,7 +24,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-uint32_t crc32(uint32_t crc, uint8_t *buf, size_t len) {
+uLong crc32(uLong crc, const Bytef *buf, uInt len) {
     crc = ~crc;
 
     while (len >= 8) {


### PR DESCRIPTION
- Fixed a typo in the arch flags
- Changed the signature of the zlib ARM crc32 implementation to match the exported zlib signature