### PR TITLE
Increase max file size from 1.2GB to 4GiB

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -308,7 +308,7 @@ unsigned fileHandler(const char * Infile, const ECTOptions& Options, int interna
             return 1;
         }
         int statcompressedfile = 0;
-        if (size < 1200000000) {//completely random value
+        if (size <= UINT_MAX) {
             if (x == "PNG" || x == "png"){
                 error = OptimizePNG(Infile, Options);
             }


### PR DESCRIPTION
I found this quite restrictive, since it is just an `if` condition: bigger does work well with ECT, I just tried with a 2GB gzip file.

`<= UINT_MAX` to have the same behavior as line 427 and line 470.