### PR TITLE
Add Dockerfile and pre-commit hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: optimize-files
+  name: Optimize Images and Zips
+  description: Losslessly optimize newly-added GZIP, ZIP, JPEG, and PNG files
+  entry: /app/ect
+  language: docker
+  files: '.*\.(png|jpe?g|zip|gz)$'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.18 as base
+WORKDIR /app
+RUN apk add --no-cache libgcc libstdc++
+
+FROM base as build
+RUN apk add --no-cache cmake g++ make nasm
+COPY . .
+RUN cmake -B build src
+RUN make -C build -j
+
+FROM base as runtime
+COPY --from=build /app/build/ect .
+CMD ["/app/ect"]


### PR DESCRIPTION
## User story

I'd like to run ECT automatically on images that are newly added to a git repository. [pre-commit](https://pre-commit.com) is a relatively common tool for running a configurable set of git hooks on changed files. It supports arbitrary hooks using Docker (among other ways).

## Proposal
This PR adds a Dockerfile for ECT, and a `.pre-commit-hooks.yaml` file describing how pre-commit should run the hook. An example user might configure the following in their `.pre-commit-config.yaml`:

```yaml
repos:
- repo: https://github.com/fhanau/Efficient-Compression-Tool
  rev: v0.10.0
  hooks:
  - id: optimize-files
  - args: ['--strict', '-9']
```

With this config, pre-commit would use ECT to optimize newly added or changed PNGs, JPEGs, ZIPs, and GZIPs.

Notably, this PR does **not** include any automation for pushing Docker images to a repository such as Docker Hub, so there's no additional infrastructure or maintenance burden (other than updating the Dockerfile if you add new compilation dependencies). On first use, pre-commit clones the repo and builds the image from source.

## Assumptions

In order to use ECT as an effective pre-commit hook, I assume that once a file has been optimized, re-running ECT on that file will not change the file, and will be reasonably fast. In my testing, this appears to be the case, but it would be nice to have some theoretical backing for this claim.