### PR TITLE
Make -zip and -gzip description in -help consistent

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,8 +58,8 @@ static void Usage() {
 #ifdef FS_SUPPORTED
             " -recurse          Recursively search directories\n"
 #endif
-            " -zip              Compress file(s) with  ZIP algorithm\n"
-            " -gzip             Compress file with GZIP algorithm\n"
+            " -zip              Compress file(s) with ZIP algorithm\n"
+            " -gzip             Compress file(s) with GZIP algorithm\n"
             " -quiet            Print only error messages\n"
             " -help             Print this help\n"
             " -keep             Keep modification time\n"


### PR DESCRIPTION
Just a minor nit, removes double space and makes the wording of the two options consistent in help.