### PR TITLE
feat: Improved compatibility & support for `--` arg

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,9 +142,16 @@ endif()
 # Enable ZLIB_CONST for everything
 add_definitions(-DZLIB_CONST)
 
-# Ensure that zlib target points to our custom zlib zlib
-set(ZLIB_ROOT "zlib/")
-find_package(ZLIB)
+# Set CMake variables so that other libraries like libpng and mozjpeg
+# can find our custom zlib when calling find_package(ZLIB REQUIRED).
+# find_package() fails (at configuration time) otherwise because the
+# zlib static library object doesn't exist until build time.
+set(ZLIB_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/zlib/")
+set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/zlib")
+# ZLIB_LIBRARY needs to be set to where the built library will end up
+set(ZLIB_LIBRARY "zlib/${CMAKE_STATIC_LIBRARY_PREFIX}zlib${CMAKE_STATIC_LIBRARY_SUFFIX}")
+# Now this check should pass
+find_package(ZLIB REQUIRED)
 
 option(ECT_MULTITHREADING "Enable multithreaded processing support" ON)
 option(ECT_MP3_SUPPORT "Enable MP3 support (not currently working)" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,7 +68,7 @@ if(WIN32)
   # as well as paths longer than 260 characters. It also configures UAC handling.
   target_sources(ect PRIVATE ect.manifest.rc)
 
-  # Disable CMake's automatic manifest generation on MSVC since we provide our own.
+  # Disable MSVC's automatic manifest generation since we provide our own.
   if(MSVC)
     target_link_options(ect PRIVATE "/MANIFEST:NO")
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,11 @@ add_executable(ect::ect ALIAS ect)
 if(MINGW)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-mno-ms-bitfields>)
   add_compile_options($<$<COMPILE_LANGUAGE:C>:-mno-ms-bitfields>)
+
+  # Ensure static linkage.
+  target_link_options(ect PRIVATE -static -static-libgcc -static-libstdc++)
+  set(CMAKE_LINK_SEARCH_START_STATIC TRUE)
+  set(CMAKE_LINK_SEARCH_END_STATIC TRUE)
 endif()
 
 if(NOT MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,19 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/../.git" AND NOT EXISTS "${CMAKE_SOURCE_DIR}/../s
     message (FATAL_ERROR "Submodules are not initialized. Run \n\tgit submodule update --init --recursive\n within the repository")
 endif()
 
+# Enable LTO for release builds
+if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
+
+  if(IPO_SUPPORTED)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    message(STATUS "IPO / LTO enabled")
+  else()
+    message(STATUS "IPO / LTO not supported: <${IPO_ERROR}>")
+  endif()
+endif()
+
 add_executable(ect
   main.cpp
   gztools.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,17 @@ if(NOT MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-sign-compare -Wno-unused -Wno-unused-parameter")
 endif()
 
+if(WIN32)
+  # Add a manifest. On Windows, this will enable proper handling of Unicode paths,
+  # as well as paths longer than 260 characters. It also configures UAC handling.
+  target_sources(ect PRIVATE ect.manifest.rc)
+
+  # Disable CMake's automatic manifest generation on MSVC since we provide our own.
+  if(MSVC)
+    target_link_options(ect PRIVATE "/MANIFEST:NO")
+  endif()
+endif()
+
 # Use -Ofast in release builds
 # TODO: This is now deprecated in clang and likely makes little difference, switch back to -O3.
 foreach(var CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELWITHDEBINFO)

--- a/src/LzFind.c
+++ b/src/LzFind.c
@@ -24,7 +24,7 @@ void MatchFinder_Create(CMatchFinder *p)
   }
   p->son = p->hash + LZFIND_HASH_SIZE;
 
-  memset(p->hash, 0, LZFIND_HASH_SIZE * sizeof(unsigned));
+  memset(p->hash, 0, LZFIND_HASH_SIZE * sizeof(UInt32));
   p->cyclicBufferPos = 0;
   p->pos = ZOPFLI_WINDOW_SIZE;
 }

--- a/src/ect.manifest
+++ b/src/ect.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="asInvoker"/>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <application>
+        <windowsSettings>
+            <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+            <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+        </windowsSettings>
+    </application>
+</assembly>

--- a/src/ect.manifest.rc
+++ b/src/ect.manifest.rc
@@ -1,0 +1,2 @@
+#include <winuser.h>
+1 RT_MANIFEST "ect.manifest"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -549,9 +549,11 @@ int main(int argc, const char * argv[]) {
     std::vector<int> args;
     int files = 0;
     if (argc >= 2){
+        bool positional_only_mode = false;
         for (int i = 1; i < argc; i++) {
             int strlen = strnlen(argv[i], 64);  //File names may be longer and are unaffected by this check
-            if (strncmp(argv[i], "-", 1) != 0){
+            if (!positional_only_mode && strcmp(argv[i], "--") == 0) {positional_only_mode = true;}
+            else if (positional_only_mode || strncmp(argv[i], "-", 1) != 0){
                 args.push_back(i);
                 files++;
             }

--- a/src/main.h
+++ b/src/main.h
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <string>
 #include <cstring>
+#include <cstdint>
 #include <vector>
 
 //Compile support for folder input. Requires std::filesystem introduced in C++17.

--- a/src/main.h
+++ b/src/main.h
@@ -13,9 +13,11 @@
 #include <vector>
 
 //Compile support for folder input. Requires std::filesystem introduced in C++17.
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L && _MSC_VER >= 1913)
+#if __has_include(<filesystem>)
 #define FS_SUPPORTED
 #include <filesystem>
+#endif
 #endif
 
 struct ECTOptions{

--- a/src/zopfli/match.h
+++ b/src/zopfli/match.h
@@ -17,13 +17,24 @@
  */
 #include <stdint.h>
 
+#if defined(__GNUC__) || defined(__clang__)
+  #define _RESTRICT __restrict__
+#elif defined(_MSC_VER)
+  #define _RESTRICT __restrict
+#else
+  #define _RESTRICT
+#endif
+
 #ifdef __GNUC__
 __attribute__ ((always_inline, hot))
+#elif defined(_MSC_VER)
+__forceinline
 #endif
-static inline const unsigned char* GetMatch(const unsigned char* __restrict__ scan,
-                                            const unsigned char* __restrict__ match,
-                                            const unsigned char* __restrict__ end
+static inline const unsigned char* GetMatch(const unsigned char* _RESTRICT scan,
+                                            const unsigned char* _RESTRICT match,
+                                            const unsigned char* _RESTRICT end
                                             , const unsigned char* safe_end) {
+#undef _RESTRICT
 #ifdef __GNUC__
   /* Optimized Function based on cloudflare's zlib fork.
    * Note that this may read up to 15 bytes beyond end,


### PR DESCRIPTION
# Improved compatibility + `--` support

Howdy!

This PR has a few fixes for building the project, as well as a new feature or two, and a fix for a segfault.

## New features

- 7b9b64278cc1f735fe16218fed4342d18c5b442b You can now use `--` to stop parsing CLI options and move on to positional arguments
  - Example: `ect -9 -- -Image-.png`
    - Treats `-9` as an option
    - Treats `-Image-.png` as a filename

Following Unix argument passing conventions, specifying "--" by itself as a command line argument signifies that every argument that follows should be treated as positional rather than as an option, even if it starts with a dash. This allows for easily passing filenames as arguments that have names beginning with dashes.

- 89a48eb97d6e7b97fdfb8899dd7c7db899be597b On Windows, you can now use `ect` on files with paths with multi-byte characters, as well as on paths longer than 260 characters
  - This is achieved by adding a manifest file to Windows builds

## Build improvements

- 5aa1946722cf5218f4dc0bb17e376afced3d2e3e LTO is now enabled in CMake for release builds, where supported

## Build fixes

- 59b6a334da5ca99d76ed692b256b3fba8b7e77bd Building the project with CMake no longer fails if you don't have an external installation of zlib, or a previous, working build
  - Previously, configuring libpng would fail on a fresh build because its `find_package` call to locate zlib would fail on account of not being able to find the library file. The library file doesn't exist at configure time, since it is a target that is built at build time, so this required a workaround to force `find_package` to find the path that the built library will *eventually* take
  - This didn't fail in some environments (including CI, in particular) because libpng's `find_package` call would fall back to finding the system zlib for the first build, and would only pick up on the custom zlib on subsequent builds in the same build tree
  - This also means that some working builds of `ect` may be using an entirely wrong zlib library (whatever system version `find_package` found)
- 2485c128472029f0a81acca1e5acd7349565dd17 Building the project with C++11 no longer fails on some toolchains (e.g. with GCC from MinGW) due to missing definitions from headers
  - Some code `#include`-ing `main.h` was relying on the `<filesystem>` header to transitively include `<cstdint>`, and would break if `<filesystem>` wasn't included, even if it was not otherwise using `<filesystem>` at all
  - Now `main.h` just also includes `<cstdint>`
- ab8138ed41f0163a8b3e06357d6a76526c87fc59 Building the project with MinGW now links *more-statically*
  - In particular, libraries such as `libgcc` and `libstdc++` were still being linked dynamically in some cases
  - Now `CMakeLists.txt` tries its darndest to make things static
- f42973d89656b8696605747235a9344e3b239db3 Compiling with MSVC no longer fails due to usage of some GCC/Clang-specific extensions
- 41321b873569d97fdc961d88bca1503a1eb1cec1 Compiling with MSVC now more accurately detects when `<filesystem>` features can be enabled
  - Previously, the feature guard relied on checking for `__cplusplus >= 201703L`, but [MSVC normally keeps this macro's value as `199711L` regardless of the actual C++ standard in use](https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus)
  - The check is now expanded to use the equivalent MSVC macro for the C++ standard version being used, as well as the `__has_include` macro

## Non-build fixes

- ca11bac6aef8d67679c8d14bfc143cd36278905d Multiple parts of `LzFind.c` have been changed to not violate [strict aliasing rules](https://accu.org/journals/overload/28/160/anonymous)
  - These were causing segfaults for me when compiler optimizations were enabled with MinGW GCC (specifically, [on line 232](https://github.com/fhanau/Efficient-Compression-Tool/commit/ca11bac6aef8d67679c8d14bfc143cd36278905d#diff-a71fea8c024d8859cdd619209e687cb4a2f3c5cab8a265d08b3be0474926924fR233-R236) before these changes)

## P.S.

<details>
<summary>
Thanks for the cool project!
</summary>
<pre>
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣼⣿⠏⣼⣿⣿⣧⠈⢷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣴⣾⣀⡀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣾⣿⠋⣰⣿⣿⣿⣿⠗⠈⡆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣠⣤⣤⣶⣞⣿⠿⠟⢻⡏
⠀⠀⠀⠀⠀⠀⠀⠀⣴⣿⣿⠃⣼⣿⣿⣿⣿⣿⡄⠀⣷⠐⣶⣶⣶⣤⣤⣀⠀⣠⣴⣾⣿⣿⠿⠛⢋⣉⣡⣤⣴⣾⠃⢸⠇
⠀⠀⠀⠀⠀⠀⢀⣾⣿⣿⠃⣼⣿⣿⣿⣿⣿⡿⠟⠀⣿⢀⣿⣿⣿⣿⣟⣡⣾⣿⣿⣿⠟⣡⣴⣿⣿⣿⣿⣿⣿⣿⠇⠈
⠀⠀⠀⠀⠀⢀⣾⣿⣿⡏⠰⣿⠿⠟⠻⢿⡟⠰⠖⠚⠛⣻⣿⣿⣿⣿⣿⣿⣿⣿⠟⠃⠘⠿⣿⣿⣿⣿⣿⣿⣿⡇⡰
⠀⠀⠀⠀⡀⣼⣿⣿⣿⡇⢀⣠⣶⡿⠗⣀⣤⣶⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣶⣦⣌⣙⠻⠿⠋⠉⡁⠁
⠀⠀⠀⣸⡇⣿⣿⣿⣿⣿⣿⡿⢋⣴⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣶⣤⣄⣀⡀
⠀⠀⢰⣿⣿⣾⣿⣿⣿⡿⠋⣴⣿⣿⣿⡿⣿⣿⣿⣿⢛⣿⣿⣿⣿⠿⣿⡿⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣯⠙⠁
⠀⠀⣾⣿⣿⣿⣿⣿⡿⢁⣾⣿⣿⣿⠋⣼⣿⣿⡿⠃⢸⣿⣿⣿⡏⢸⣿⡏⠀⠹⣿⣿⣧⠹⣿⣿⣿⣿⡻⣿⣷⡀
⠀⠀⣿⣿⣿⣿⣿⡿⢁⣾⣿⣿⣿⠃⣼⠿⠿⠟⠁⠠⠾⢿⣿⠏⢀⣿⣿⠃⣆⠀⢹⣿⣿⠀⢻⣿⣿⣿⡇⢿⣿⣷
⠀⠀⣿⣿⣿⣿⣿⠃⣼⣿⣿⣿⡇⠀⣴⠖⠀⠀⢀⡶⢤⡄⠁⠀⣼⡿⠃⣼⣿⡀⢸⣿⡿⠀⠘⣿⣿⣿⡇⢸⣿⣿⡇
⠀⠀⣿⣿⣿⣿⠇⠀⣿⣿⣿⣿⠀⠔⠁⠀⠁⠀⠀⠈⠁⠀⠁⢰⠟⣡⣾⣿⣿⠇⠀⢉⠁⠀⠀⠛⠿⣿⠇⣸⣿⣿⣷
⠀⠀⢿⣿⣿⣿⠀⢠⣿⣿⣿⣿⠀⠀⠀⠀⣤⣤⠀⠀⠀⠀⠀⠁⣾⣿⣿⣿⣿⣷⠀⠏⣼⡇⠀⣷⣦⡜⠀⣿⣿⣿⡏
⠀⠀⢸⣿⣿⡏⠀⠸⠿⠿⣿⣿⠀⣾⡇⠀⢿⠟⠀⠀⠀⠀⣦⣸⣿⣿⣿⣿⣿⢟⢀⡼⠿⠇⢠⣿⡿⠁⠀⣿⣿⣿⠃
⠀⠀⠘⣿⣿⠇⢀⣤⣶⣄⠈⢿⡀⢻⡇⠀⠀⠀⢀⡀⠀⢸⣿⣿⣿⣿⣿⣿⡟⠁⠀⠀⠀⠀⠀⠙⢠⡂⠀⣿⡿⠁
⠀⠀⠀⣿⡏⠀⣾⣿⣿⣿⠀⢸⣧⠘⣿⡀⠀⠀⠈⠁⢀⣾⣿⣿⣿⣿⣿⣿⣏⢀⣠⣤⣄⣠⣀⠀⢠⠁⠐⠋
⠀⠀⠀⣿⣧⠀⢿⣿⣿⣿⡄⠘⠿⣧⠸⣿⣦⣤⣤⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣯⠀⢸⡇
⠀⠀⠀⣿⠟⠀⢈⣛⠻⢿⣧⠀⠀⢈⣁⡘⣿⣿⣿⣿⣿⡿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀⢸⡇
⠀⠀⠀⠁⣠⣾⣿⣿⣷⣦⠙⢷⡄⠀⢻⣿⣿⣿⣿⣿⣿⣷⣌⠻⢿⣿⣿⢟⣡⣿⣿⣿⣿⣿⣿⣿⣿⠀⣿⣷
⠀⠀⡀⠀⣿⡿⠿⢛⣛⠛⠇⢸⣷⠀⠀⠙⠿⢿⠿⠿⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠁⠰⣿⣿⣇
⠀⢀⣿⠀⢹⣷⣿⣿⣿⣿⣦⡈⢿⠀⡄⠀⠀⠀⠀⠀⠀⠹⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠀⠀⠀⠀⢿⣿⣿⡀
⠀⣼⣿⡀⢸⣿⣿⠿⠛⣛⡛⠃⢸⡆⠸⠀⢰⡀⠀⠀⠀⠀⠤⠠⠤⠡⠁⠀⠀⠀⠀⠀⠀⡀⠀⠀⠀⠀⠘⣿⣿⡇
⢰⣿⣿⡇⠀⢹⣷⣾⣿⣿⣿⡇⢈⣯⠀⠂⠸⣷⠀⠀⠀⠀⠀⠀⠠⠐⠀⠀⠀⠀⠀⠀⠀⠘⡄⠀⠀⠀⠀⣿⣿⣿
⣾⣿⣿⡇⠀⠀⢹⣟⣉⣉⣥⣤⠈⡿⠀⠀⢰⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⢠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿
⣿⣿⣿⡇⠀⠀⠀⠛⠛⠛⠛⠁⠀⠀⠀⢀⣾⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣼⣿⡇
</pre>
</details>